### PR TITLE
Update revised_armor.tpa

### DIFF
--- a/item_rev/components/revised_armor.tpa
+++ b/item_rev/components/revised_armor.tpa
@@ -92,9 +92,9 @@ ACTION_PHP_EACH armor AS ind => res BEGIN
             xres=value
             GET_OFFSET_ARRAY effects ITM_V10_GEN_EFFECTS
             FOR (opcode=86;opcode<90;++opcode) BEGIN
+              exists=0
               PHP_EACH effects AS i => r BEGIN // check if the resistance opcode already exists
                 READ_SHORT r op
-                exists=0
                 PATCH_IF op=opcode BEGIN
                   WRITE_LONG r+4 (THIS+value)>100 ? 100 : (THIS+value) // don't go over 100
                   exists=1


### PR DESCRIPTION
In some cases, if an armour already has resistance to physical damage, this was increased by the double of what was expected.

Ex: DWCHAN02, DWPLAT01, ISHCHA (from Innershade)